### PR TITLE
fix output in vllm_runner w/o use_cache

### DIFF
--- a/lcb_runner/runner/vllm_runner.py
+++ b/lcb_runner/runner/vllm_runner.py
@@ -50,4 +50,7 @@ class VLLMRunner(BaseRunner):
                     ]
                     outputs[index] = [o.text for o in output.outputs]
                 self.save_cache()
+            else:
+                for index, output in zip(remaining_indices, outputs):
+                    outputs[index] = [o.text for o in output.outputs]
         return outputs


### PR DESCRIPTION
Great work! But I run into problems when running the follow command without using `--use_cache`, as the outputs are `vllm.outputs.RequestOutput` and can not be correctly parsed by the following code extractor.
```
python -m lcb_runner.runner.main --model {model_name} --scenario codegeneration
```
I fix the bug on the output. Please take a look.