### PR TITLE
Modify sys.recursionlimit to avoid sub-process crashing unexpectedly.

### DIFF
--- a/lcb_runner/evaluation/testing_util.py
+++ b/lcb_runner/evaluation/testing_util.py
@@ -111,7 +111,7 @@ def run_test(sample, test=None, debug=False, timeout=6):
         return in_outs, {"error": "no test code provided"}
     elif test is not None:
         results = []
-        sol = "from string import *\nfrom re import *\nfrom datetime import *\nfrom collections import *\nfrom heapq import *\nfrom bisect import *\nfrom copy import *\nfrom math import *\nfrom random import *\nfrom statistics import *\nfrom itertools import *\nfrom functools import *\nfrom operator import *\nfrom io import *\nfrom sys import *\nfrom json import *\nfrom builtins import *\nfrom typing import *\nimport string\nimport re\nimport datetime\nimport collections\nimport heapq\nimport bisect\nimport copy\nimport math\nimport random\nimport statistics\nimport itertools\nimport functools\nimport operator\nimport io\nimport sys\nimport json\nsys.setrecursionlimit(6*10**5)\n"
+        sol = "from string import *\nfrom re import *\nfrom datetime import *\nfrom collections import *\nfrom heapq import *\nfrom bisect import *\nfrom copy import *\nfrom math import *\nfrom random import *\nfrom statistics import *\nfrom itertools import *\nfrom functools import *\nfrom operator import *\nfrom io import *\nfrom sys import *\nfrom json import *\nfrom builtins import *\nfrom typing import *\nimport string\nimport re\nimport datetime\nimport collections\nimport heapq\nimport bisect\nimport copy\nimport math\nimport random\nimport statistics\nimport itertools\nimport functools\nimport operator\nimport io\nimport sys\nimport json\nsys.setrecursionlimit(10**4)\n"
         if debug:
             print(f"loading test code = {datetime.now().time()}")
 


### PR DESCRIPTION
**Issue Summary**  
While running self-repair using Llama-3.3-70B-Instruct, I encountered a small number of samples (96 out of 7130) with `error_code=-5`. These errors were not recognized as runtime errors or exceptions. Upon investigation, I traced the issue to a subprocess crash caused by a `RecursionError` in the provided sample code.

**Details and Reproduction Steps**  
I identified that the subprocess crashed without raising a recognizable exception when the `RecursionError` occurred. Below is a minimal reproducible example demonstrating the issue:

```python
import multiprocessing
from pyext import RuntimeModule
import faulthandler

# Example inputs
sol = """
from string import *
from re import *
from datetime import *
from collections import *
from heapq import *
from bisect import *
from copy import *
from math import *
from random import *
from statistics import *
from itertools import *
from functools import *
from operator import *
from io import *
from sys import *
from json import *
from builtins import *
from typing import *
import string
import re
import datetime
import collections
import heapq
import bisect
import copy
import math
import random
import statistics
import itertools
import functools
import operator
import io
import sys
import json
sys.setrecursionlimit(6*10**5)
from typing import List

class Solution:
    def findSafeWalk(self, grid: List[List[int]], health: int) -> bool:
        m, n = len(grid), len(grid[0])
        memo = {}

        def dfs(i, j, health):
            if (i, j, health) in memo:
                return memo[(i, j, health)]
            if i < 0 or i >= m or j < 0 or j >= n or health <= 0:
                return False
            if i == m - 1 and j == n - 1:
                return health > 0
            health -= grid[i][j]
            res = dfs(i + 1, j, health) or dfs(i - 1, j, health) or dfs(i, j + 1, health) or dfs(i, j - 1, health)
            memo[(i, j, health + grid[i][j])] = res
            return res

        return dfs(0, 0, health)
"""
method_name = "findSafeWalk"
inputs = ([[0, 1, 0, 0, 0], [0, 1, 0, 1, 0], [0, 0, 0, 1, 0]], 1)

def _temp_run(sol_code, method_name, inputs, result):
    try:
        # Create a runtime module from the string
        tmp_sol = RuntimeModule.from_string("tmp_sol", "", sol_code)
        tmp_sol = tmp_sol.Solution()

        # Get the method from the module
        method = getattr(tmp_sol, method_name)
        faulthandler.enable()
        # Call the method with the inputs and store the result
        output = method(*inputs)
        result.append(output)
    except AttributeError as e:
        result.append(f"AttributeError: {e}")
    except Exception as e:
        result.append(f"An unexpected error occurred: {e}")

# Use multiprocessing to execute the function with a timeout
manager = multiprocessing.Manager()
result = manager.list()

p = multiprocessing.Process(target=_temp_run, args=(sol, method_name, inputs, result))
p.start()
p.join(timeout=10)  # Adjust timeout as needed

if p.is_alive():
    print("Process exceeded timeout and will be terminated.")
    p.kill()
else:
    print("Process completed.")

# Check and print the result
if result:
    print(f"Output: {result[0]}")
else:
    print("No result returned from the process.")
```

**Observed Behavior**  
When using `sys.setrecursionlimit(6 * 10**5)`, the code produces a segmentation fault and crashes the subprocess:  

```
Fatal Python error: Segmentation fault

Current thread 0x00007c283cff1740 (most recent call first):
  ...
  
  File "<string>", line 44 in dfs
  File "<string>", line 44 in dfs
  File "<string>", line 44 in dfs
  File "<string>", line 44 in dfs
  File "<string>", line 44 in dfs
  ...
Process completed.
No result returned from the process.
```

When the recursion limit is reduced to `10**4`, the `RecursionError` is caught as expected:  

```
Process completed.
Output: An unexpected error occurred: maximum recursion depth exceeded in comparison
```

**Proposed Solution**  
Adjust the recursion limit from `6*10**5` to `10**4` to avoid subprocess failures.  
