### PR TITLE
Fix: memory explosion issue

### DIFF
--- a/lcb_runner/evaluation/compute_code_generation_metrics.py
+++ b/lcb_runner/evaluation/compute_code_generation_metrics.py
@@ -43,7 +43,7 @@ def check_correctness(sample, generation, timeout, debug=True):
         timeout=(timeout + 1) * len(json.loads(sample["input_output"])["inputs"]) + 5
     )
     try:
-        os.kill(p.pid, 9) # Force to kill the process for safety
+        os.kill(p.pid, 9) # Force to kill the process by PID for safety
     except:
         None
     if p.is_alive():

--- a/lcb_runner/evaluation/compute_code_generation_metrics.py
+++ b/lcb_runner/evaluation/compute_code_generation_metrics.py
@@ -42,6 +42,10 @@ def check_correctness(sample, generation, timeout, debug=True):
     p.join(
         timeout=(timeout + 1) * len(json.loads(sample["input_output"])["inputs"]) + 5
     )
+    try:
+        os.kill(p.pid, 9) # Force to kill the process for safety
+    except:
+        None
     if p.is_alive():
         p.kill()
     if not result:

--- a/lcb_runner/evaluation/testing_util.py
+++ b/lcb_runner/evaluation/testing_util.py
@@ -434,7 +434,7 @@ def run_test(sample, test=None, debug=False, timeout=6):
 
     # Disable functionalities that can make destructive changes to the test.
     # max memory is set to 4GB
-    reliability_guard()
+    reliability_guard(4 * 1024 * 1024 * 1024)
 
     if debug:
         print(f"start = {datetime.now().time()}")


### PR DESCRIPTION
Hi,

I find sometimes there are memory explosion issues when using LCB. Memory usage continuously increases until my server (max 1TB RAM) becomes IDLE.
![image](https://github.com/user-attachments/assets/619569b4-52c5-4b7a-803d-bca42a50127a)


I make these two changes, and memory explosion issues have never shown again.

1. Force to kill process by PID 
2. Set default memory limit to 4GB (4 * 1024 * 1024 * 1024), as stated in the original comments.

Hope this fix looks good to you. :)
Thanks.