### PR TITLE
Default stop flag to None

### DIFF
--- a/lcb_runner/runner/parser.py
+++ b/lcb_runner/runner/parser.py
@@ -70,7 +70,7 @@ def get_args():
     )
     parser.add_argument(
         "--stop",
-        default="###",
+        default=None,  # default to None to avoid premature cutoff
         type=str,
         help="Stop token (use `,` to separate multiple tokens)",
     )
@@ -134,7 +134,7 @@ def get_args():
 
     args = parser.parse_args()
 
-    args.stop = args.stop.split(",")
+    args.stop = args.stop.split(",") if args.stop else None # stop flag is default to None
 
     if args.tensor_parallel_size == -1:
         args.tensor_parallel_size = torch.cuda.device_count()


### PR DESCRIPTION
We identified a bug in the parser.py file, where the default stop token for model generation is "###":

```
parser.add_argument(
        "--stop",
        default="###",
        type=str,
        help="Stop token (use `,` to separate multiple tokens)",
    )
```

This will cutoff model response prematurely. For example, in our evaluations, we find that Qwen3-8B likes to output "### Solution code" so the solution code is discarded.

Currently, this feature is not disabled for vllm runner, which is the default entry point for most open source models.

We changed the default flag to None and also handled the none type in subsequent logic. 