### PR TITLE
Added precise python backtick check

### DIFF
--- a/lcb_runner/utils/extraction_utils.py
+++ b/lcb_runner/utils/extraction_utils.py
@@ -10,6 +10,25 @@ def extract_code(model_output: str, lmstyle: LMStyle):
     elif lmstyle == LMStyle.GenericBase:
         return model_output.strip()
     else:
+        # First try to extract ```python if not then try ```
+        python_start_indices = [
+            i for i, line in enumerate(outputlines) 
+            if "```python" in line.lower()
+        ]
+        if python_start_indices:
+            # Find the next ``` after the python block start
+            start_idx = python_start_indices[-1]
+            end_indices = [
+                i for i, line in enumerate(outputlines[start_idx+1:], start_idx+1)
+                if "```" in line
+            ]
+            if end_indices:
+                return "\n".join(outputlines[start_idx + 1 : end_indices[0]])
+            else: 
+                # if no end_indices, just return from start_idx
+                return "\n".join(outputlines[start_idx + 1 :])
+
+        # Fallback to original logic
         indexlines = [i for i, line in enumerate(outputlines) if "```" in line]
         if len(indexlines) < 2:
             return ""


### PR DESCRIPTION
We find a bug in extraction_utils.py where the code block is identified as the content within the last pair of backticks, specifically handled by this logic:

```
return "\n".join(outputlines[indexlines[-2] + 1 : indexlines[-1]])
```

However, this logic is vulnerable because whenever the model decides to put a text summary as a markdown component after the solution code, the summary will be extracted, not the python code.

To fix this, we changed the extraction logic to look specifically for the last pair of backticks with python tags, ensuring that python code is extracted. Only when no python code is detected do we fall back to the original implementation.