### PR TITLE
accept output if no backticks as well

### DIFF
--- a/lcb_runner/utils/extraction_utils.py
+++ b/lcb_runner/utils/extraction_utils.py
@@ -12,7 +12,7 @@ def extract_code(model_output: str, lmstyle: LMStyle):
     else:
         indexlines = [i for i, line in enumerate(outputlines) if "```" in line]
         if len(indexlines) < 2:
-            return ""
+            return model_output.strip()
         # return "\n".join(outputlines[indexlines[0] + 1 : indexlines[1]])
         return "\n".join(outputlines[indexlines[-2] + 1 : indexlines[-1]])
 


### PR DESCRIPTION
sometimes the models output code without backticks, this change helps capture those cases. Many times, this code is correct. This could be because some models are trained to output code differently. If the output is wrong, the returned code would just fail.