### PR TITLE
Fix package discovery to include subpackages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ dependencies = [
     "together>=0.21.0",
 ]
 
-[tool.setuptools]
-packages = ["lcb_runner"]
+[tool.setuptools.packages.find]
+include = ["lcb_runner*"]


### PR DESCRIPTION
Fix to the current `pyproject.toml` configuration only including the top-level `lcb_runner` package. Subpackages like `lcb_runner.evaluation` are not included when doing a non-editable install.

The README suggests editable installs (uv pip install -e .), but editable installs aren't always possible, e.g. for uv workspaces and other dependency managers that resolve packages from git URLs.

This fix makes the package work correctly for all installation methods.

Also, since vllm only has linux wheels and requires CUDA, it could maybe be beneficial to add 
`"vllm>=0.5.0.post1; sys_platform == 'linux'"`,  
or making it an optional dependency in `pyproject.toml` to still allow for API-based evals on non-Linux setups. 

PS. Thanks for your work on this benchmark :)